### PR TITLE
.gitignore ファイルの作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,43 @@
+.vim/plugin/.vim/.netrwhist
+.vim/plugin/.vim/dein/
+
+# OSX
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+## Icon must end with two \r
+Icon
+
+## Thumbnails
+._*
+
+## Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+## Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+
+# Vim
+## swap
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+# session
+Session.vim
+# temporary
+.netrwhist
+*~
+
+## auto-generated tag files
+tags


### PR DESCRIPTION
#4

`.gitignore` ファイルを作成し、
一般的な設定に加えて特定のファイルを監視対象から外す
- やること
  - [x] 以下のファイルをgitの監視対象から除外
    - .DS_store
    - dein.vimでインストールしたプラグインファイル
    - .netrwhist
