### PR TITLE
Vimの開発用（一般）のプラグインを導入

### DIFF
--- a/.vim/plugin/.vim/rc/dein.toml
+++ b/.vim/plugin/.vim/rc/dein.toml
@@ -24,3 +24,6 @@ repo = 'scrooloose/nerdtree'
 
 [[plugins]]
 repo = 'Xuyuanp/nerdtree-git-plugin'
+
+[[plugins]]
+repo = 'airblade/vim-gitgutter'

--- a/.vim/plugin/.vim/rc/dein.toml
+++ b/.vim/plugin/.vim/rc/dein.toml
@@ -15,3 +15,6 @@ repo = 'Shougo/neosnippet-snippets'
 # custom plugins
 [[plugins]]
 repo = 'itchyny/lightline.vim'
+
+[[plugins]]
+repo = 'bronson/vim-trailing-whitespace'

--- a/.vim/plugin/.vim/rc/dein.toml
+++ b/.vim/plugin/.vim/rc/dein.toml
@@ -21,3 +21,6 @@ repo = 'bronson/vim-trailing-whitespace'
 
 [[plugins]]
 repo = 'scrooloose/nerdtree'
+
+[[plugins]]
+repo = 'Xuyuanp/nerdtree-git-plugin'

--- a/.vim/plugin/.vim/rc/dein.toml
+++ b/.vim/plugin/.vim/rc/dein.toml
@@ -18,3 +18,6 @@ repo = 'itchyny/lightline.vim'
 
 [[plugins]]
 repo = 'bronson/vim-trailing-whitespace'
+
+[[plugins]]
+repo = 'scrooloose/nerdtree'

--- a/.vim/setting/.vimrc.plugins
+++ b/.vim/setting/.vimrc.plugins
@@ -5,3 +5,16 @@ cnoremap tree NERDTreeToggle
 
 " vim-trailing-whitespace
 autocmd BufWritePre * :FixWhitespace
+
+" nerdtree-git-plugin
+let g:NERDTreeIndicatorMapCustom = {
+    \ "Modified"  : "m",
+    \ "Staged"    : "s",
+    \ "Untracked" : "?",
+    \ "Renamed"   : "r",
+    \ "Unmerged"  : "~",
+    \ "Deleted"   : "d",
+    \ "Dirty"     : "*",
+    \ "Clean"     : "c",
+    \ "Unknown"   : "?"
+    \ }

--- a/.vim/setting/.vimrc.plugins
+++ b/.vim/setting/.vimrc.plugins
@@ -2,3 +2,6 @@
 autocmd StdinReadPre * let s:std_in=1
 autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | NERDTree | endif
 cnoremap tree NERDTreeToggle
+
+" vim-trailing-whitespace
+autocmd BufWritePre * :FixWhitespace

--- a/.vim/setting/.vimrc.plugins
+++ b/.vim/setting/.vimrc.plugins
@@ -1,0 +1,4 @@
+" NERDTree
+autocmd StdinReadPre * let s:std_in=1
+autocmd VimEnter * if argc() == 0 && !exists("s:std_in") | NERDTree | endif
+cnoremap tree NERDTreeToggle

--- a/.vimrc
+++ b/.vimrc
@@ -18,3 +18,5 @@ source ~/.dotfiles/.vim/setting/.vimrc.search
 source ~/.dotfiles/.vim/setting/.vimrc.environment
 " コマンドライン
 source ~/.dotfiles/.vim/setting/.vimrc.cli
+" プラグインの設定
+source ~/.dotfiles/.vim/setting/.vimrc.plugins


### PR DESCRIPTION
以下のプラグインをインストールに加えて、
プラグイン用の設定vimrcも追加
- vim-trailing-whitespace
- nerdtree
- vim-trailing-whitespace
- nerdtree-git-plugin
- vim-gitgutter
