### PR TITLE
vimの補完候補表示の設定を変更

### DIFF
--- a/.vim/setting/.vimrc.screen
+++ b/.vim/setting/.vimrc.screen
@@ -12,6 +12,7 @@ set helpheight=999    " ヘルプを全画面で表示
 set list    " 不可視文字を表示
 set listchars=tab:▸\ ,eol:↲    " 不可視文字の表示記号を指定
 set showmatch " 括弧の対応関係を表示
+set completeopt=menuone " 候補が1つしかないときもポップアップメニューを使用
 
 hi Pmenu ctermbg=darkcyan ctermfg=white
 hi PmenuSel ctermbg=brown ctermfg=black


### PR DESCRIPTION
補完時にプレビューが表示されるのを止めて、
候補が1つしかない時もポップアップメニューが表示されるのみの設定に変更
